### PR TITLE
Fix: Platform-aware connectivity monitoring for web and mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 0.1.1 - 2025-09-22
+- **Platform-aware Connectivity Check**: Implemented a platform-specific strategy to check for internet connection. 
+The app now uses the efficient `onConnectivityChanged` stream on mobile platforms and a more reliable periodic timer 
+for the web to prevent dialog issues.
+
+
 ## 0.1.0 - 2025-07-29
 
-###Added
+## Added
 
 - **Optional strict mode**: Introduced `checkActualInternet` flag to toggle between basic
   connectivity check and actual internet verification.

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import connectivity_plus
+import network_info_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -147,26 +147,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -280,10 +280,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -296,10 +296,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/lib/src/utils/connectivity_monitor.dart
+++ b/lib/src/utils/connectivity_monitor.dart
@@ -47,18 +47,17 @@ class ConnectivityMonitor with ChangeNotifier {
   }
 
   /// Checks if the internet connection is working.
-  Future<bool> isInternetWorking() async {
-    try {
-      if (!checkActualInternet) {
-        return true;
-      }
-      final response = await http
-          .get(Uri.parse('https://www.google.com'))
-          .timeout(const Duration(seconds: 10));
-
-      return response.statusCode == 200; // Internet is working
-    } catch (_) {
-      return false; // No actual internet
+Future<bool> isInternetWorking() async {
+  try {
+    if (!checkActualInternet) {
+      return true;
     }
+    final response = await http
+        .get(Uri.parse('https://one.one.one.one'))
+        .timeout(const Duration(seconds: 10));
+    return response.statusCode == 200;
+  } on Exception catch (_) {
+    return false;
   }
+}
 }

--- a/lib/src/utils/connectivity_monitor.dart
+++ b/lib/src/utils/connectivity_monitor.dart
@@ -49,7 +49,8 @@ class ConnectivityMonitor with ChangeNotifier {
 
   // Use the stream listener for mobile, as it's more efficient.
   void _startMobileInternetCheck() {
-    _connectivitySubscription = _connectivityManager.onConnectivityChanged.listen(_internetResult);
+    _connectivitySubscription = _connectivityManager.onConnectivityChanged
+        .listen(_internetResult);
   }
 
   void _internetResult(List<ConnectivityResult> result) async {

--- a/lib/src/utils/connectivity_monitor.dart
+++ b/lib/src/utils/connectivity_monitor.dart
@@ -1,11 +1,15 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart' show kIsWeb;
 
 /// A class that monitors the internet connectivity status and notifies listeners
 /// of any changes.
 class ConnectivityMonitor with ChangeNotifier {
   bool _hasInternet = true;
+  Timer? _timer;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
 
   /// Returns true if there is internet connectivity.
   bool get hasInternet => _hasInternet;
@@ -24,16 +28,28 @@ class ConnectivityMonitor with ChangeNotifier {
     this._connectivityManager, {
     required this.checkActualInternet,
   }) {
-    _checkInternet();
-    _listenInternet();
+    if (kIsWeb) {
+      _startWebInternetCheck();
+    } else {
+      _startMobileInternetCheck();
+    }
   }
 
-  void _checkInternet() {
-    _connectivityManager.checkConnectivity().then(_internetResult);
+  // Use a periodic timer for web as connectivity_plus stream is unreliable.
+  void _startWebInternetCheck() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 4), (timer) async {
+      final isActuallyWorking = await isInternetWorking();
+      if (_hasInternet != isActuallyWorking) {
+        _hasInternet = isActuallyWorking;
+        notifyListeners();
+      }
+    });
   }
 
-  void _listenInternet() {
-    _connectivityManager.onConnectivityChanged.listen(_internetResult);
+  // Use the stream listener for mobile, as it's more efficient.
+  void _startMobileInternetCheck() {
+    _connectivitySubscription = _connectivityManager.onConnectivityChanged.listen(_internetResult);
   }
 
   void _internetResult(List<ConnectivityResult> result) async {
@@ -47,17 +63,27 @@ class ConnectivityMonitor with ChangeNotifier {
   }
 
   /// Checks if the internet connection is working.
-Future<bool> isInternetWorking() async {
-  try {
-    if (!checkActualInternet) {
-      return true;
+  Future<bool> isInternetWorking() async {
+    try {
+      if (!checkActualInternet) {
+        return true;
+      }
+      final url = kIsWeb
+          ? Uri.parse('https://one.one.one.one')
+          : Uri.parse('https://www.google.com');
+
+      final response = await http.get(url).timeout(const Duration(seconds: 10));
+
+      return response.statusCode == 200;
+    } on Exception {
+      return false;
     }
-    final response = await http
-        .get(Uri.parse('https://one.one.one.one'))
-        .timeout(const Duration(seconds: 10));
-    return response.statusCode == 200;
-  } on Exception catch (_) {
-    return false;
   }
-}
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _connectivitySubscription?.cancel();
+    super.dispose();
+  }
 }


### PR DESCRIPTION
Summary of Changes
This pull request introduces a more robust and reliable method for monitoring internet connectivity across both web and mobile platforms. The previous implementation, which relied solely on the connectivity_plus stream listener, was unreliable on Flutter web, causing the "no internet" dialog not to appear when the connection was lost.

To resolve this, the ConnectivityMonitor has been updated to be platform-aware:

- For mobile platforms, the efficient connectivity_plus stream is still used as it is reliable and resource-friendly.
- For web, a periodic timer is now used to perform a proactive internet check. This bypasses the unreliable stream and ensures the dialog is correctly displayed when the internet connection is lost.